### PR TITLE
Feature/link anonymous to google

### DIFF
--- a/demo/project.godot
+++ b/demo/project.godot
@@ -26,6 +26,7 @@ Firebase="*res://addons/GodotFirebaseAndroid/Firebase.gd"
 
 window/size/viewport_width=720
 window/size/viewport_height=1280
+window/stretch/mode="canvas_items"
 window/handheld/orientation=1
 
 [editor_plugins]

--- a/demo/scenes/authentication.gd
+++ b/demo/scenes/authentication.gd
@@ -13,6 +13,8 @@ func _notification(what: int) -> void:
 func _ready() -> void:
 	Firebase.auth.auth_success.connect(print_output.bind("auth_success"))
 	Firebase.auth.auth_failure.connect(print_output.bind("auth_failure"))
+	Firebase.auth.link_with_google_success.connect(print_output.bind("link_with_google_success"))
+	Firebase.auth.link_with_google_failure.connect(print_output.bind("link_with_google_failure"))
 	Firebase.auth.sign_out_success.connect(print_output.bind("sign_out_success"))
 	Firebase.auth.email_verification_sent.connect(print_output.bind("email_verification_sent"))
 	Firebase.auth.password_reset_sent.connect(print_output.bind("password_reset_sent"))

--- a/demo/scenes/authentication.gd
+++ b/demo/scenes/authentication.gd
@@ -38,6 +38,10 @@ func _on_google_sign_in_pressed() -> void:
 	Firebase.auth.sign_in_with_google()
 
 
+func _on_link_anonymous_with_google_pressed() -> void:
+	Firebase.auth.link_anonymous_with_google()
+
+
 func _on_get_user_data_pressed() -> void:
 	print_output(Firebase.auth.get_current_user_data(), "Current User Data")
 

--- a/demo/scenes/authentication.tscn
+++ b/demo/scenes/authentication.tscn
@@ -135,6 +135,16 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Sign In With Google"
 
+[node name="link_anonymous_with_google" type="Button" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(120, 60)
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+text = "Link Anonymous To Google"
+
 [node name="get_user_data" type="Button" parent="MarginContainer/VBoxContainer"]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
@@ -186,6 +196,7 @@ theme_override_font_sizes/normal_font_size = 32
 [connection signal="pressed" from="MarginContainer/VBoxContainer/email_verification" to="." method="_on_email_verification_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/password_reset" to="." method="_on_password_reset_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/google_sign_in" to="." method="_on_google_sign_in_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/link_anonymous_with_google" to="." method="_on_link_anonymous_with_google_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/get_user_data" to="." method="_on_get_user_data_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/is_signed_in" to="." method="_on_is_signed_in_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/sign_out" to="." method="_on_sign_out_pressed"]

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -16,6 +16,12 @@ The Firebase Authentication module in **GodotFirebaseAndroid** supports anonymou
 - `auth_failure(error_message: String)`
   Emitted when an authentication operation fails.
 
+- `link_with_google_success(current_user_data: Dictionary)`
+  Emitted when an anonymous user is successfully linked to a Google account.
+
+- `link_with_google_failure(error_message: String)`
+  Emitted when linking an anonymous user to a Google account fails.
+
 - `sign_out_success(success: bool)`
   Emitted after a sign-out operation. `true` indicates success.
 
@@ -109,7 +115,7 @@ Firebase.auth.sign_in_with_google()
 
 Links the currently signed-in anonymous user to a Google account, converting it to a permanent account. The anonymous user's UID and data are preserved. Must be called while an anonymous user is signed in.
 
-**Emits:** `auth_success` or `auth_failure`.
+**Emits:** `link_with_google_success` or `link_with_google_failure`.
 
 ```gdscript
 Firebase.auth.link_anonymous_with_google()

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -105,11 +105,30 @@ Firebase.auth.sign_in_with_google()
 ---
 
 {: .text-green-100 }
+### link_anonymous_with_google()
+
+Links the currently signed-in anonymous user to a Google account, converting it to a permanent account. The anonymous user's UID and data are preserved. Must be called while an anonymous user is signed in.
+
+**Emits:** `auth_success` or `auth_failure`.
+
+```gdscript
+Firebase.auth.link_anonymous_with_google()
+```
+
+---
+
+{: .text-green-100 }
 ### get_current_user_data() -> Dictionary
 
-If no user is signed in, returns an dictionary with error.
+If no user is signed in, returns a dictionary with error.
 
-**Returns** a dictionary containing the currently signed-in user's data.
+**Returns** a dictionary containing the currently signed-in user's data:
+- `name` — Display name
+- `email` — Email address
+- `photoUrl` — Profile photo URL
+- `emailVerified` — Whether the email is verified
+- `isAnonymous` — Whether the user is anonymous
+- `uid` — User ID
 
 ```gdscript
 Firebase.auth.get_current_user_data()

--- a/firebase/build.gradle.kts
+++ b/firebase/build.gradle.kts
@@ -18,7 +18,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
 
         manifestPlaceholders["godotPluginName"] = pluginName
         manifestPlaceholders["godotPluginPackageName"] = pluginPackageName

--- a/firebase/export_scripts_template/modules/Auth.gd
+++ b/firebase/export_scripts_template/modules/Auth.gd
@@ -2,6 +2,8 @@ extends Node
 
 signal auth_success(current_user_data: Dictionary)
 signal auth_failure(error_message: String)
+signal link_with_google_success(current_user_data: Dictionary)
+signal link_with_google_failure(error_message: String)
 signal sign_out_success(success: bool)
 signal password_reset_sent(success: bool)
 signal email_verification_sent(success: bool)
@@ -14,6 +16,8 @@ func _connect_signals():
 		return
 	_plugin_singleton.connect("auth_success", auth_success.emit)
 	_plugin_singleton.connect("auth_failure", auth_failure.emit)
+	_plugin_singleton.connect("link_with_google_success", link_with_google_success.emit)
+	_plugin_singleton.connect("link_with_google_failure", link_with_google_failure.emit)
 	_plugin_singleton.connect("sign_out_success", sign_out_success.emit)
 	_plugin_singleton.connect("password_reset_sent", password_reset_sent.emit)
 	_plugin_singleton.connect("email_verification_sent", email_verification_sent.emit)

--- a/firebase/export_scripts_template/modules/Auth.gd
+++ b/firebase/export_scripts_template/modules/Auth.gd
@@ -43,6 +43,10 @@ func sign_in_with_google() -> void:
 	if _plugin_singleton:
 		_plugin_singleton.signInWithGoogle()
 
+func link_anonymous_with_google() -> void:
+	if _plugin_singleton:
+		_plugin_singleton.linkAnonymousWithGoogle()
+
 func get_current_user_data() -> Dictionary:
 	var user_data: Dictionary
 	if _plugin_singleton:

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
@@ -30,6 +30,8 @@ class Authentication(private val plugin: FirebasePlugin) {
 		val signals: MutableSet<SignalInfo> = mutableSetOf()
 		signals.add(SignalInfo("auth_success", Dictionary::class.java))
 		signals.add(SignalInfo("auth_failure", String::class.java))
+		signals.add(SignalInfo("link_with_google_success", Dictionary::class.java))
+		signals.add(SignalInfo("link_with_google_failure", String::class.java))
 		signals.add(SignalInfo("sign_out_success", Boolean::class.javaObjectType))
 		signals.add(SignalInfo("password_reset_sent", Boolean::class.javaObjectType))
 		signals.add(SignalInfo("email_verification_sent", Boolean::class.javaObjectType))
@@ -69,9 +71,14 @@ class Authentication(private val plugin: FirebasePlugin) {
 					authWithGoogle(account.idToken!!)
 				}
 			} catch (e: ApiException) {
+				val wasLinking = isLinkingAnonymous
 				isLinkingAnonymous = false
 				Log.w(TAG, "Google sign in failed", e)
-				plugin.emitGodotSignal("auth_failure", e.message ?: "Unknown error")
+				if (wasLinking) {
+					plugin.emitGodotSignal("link_with_google_failure", e.message ?: "Unknown error")
+				} else {
+					plugin.emitGodotSignal("auth_failure", e.message ?: "Unknown error")
+				}
 			}
 		}
 	}
@@ -80,7 +87,7 @@ class Authentication(private val plugin: FirebasePlugin) {
 		val currentUser = auth.currentUser
 		if (currentUser != null) {
 			Log.d(TAG, "User already signed in (uid=${currentUser.uid}, isAnonymous=${currentUser.isAnonymous}). Skipping anonymous sign-in.")
-			plugin.emitGodotSignal("auth_success", getCurrentUser())
+			plugin.emitGodotSignal("auth_failure", "User is already signed in.")
 			return
 		}
 		auth.signInAnonymously()
@@ -163,20 +170,15 @@ class Authentication(private val plugin: FirebasePlugin) {
 		val currentUser = auth.currentUser
 		if (currentUser == null) {
 			Log.e(TAG, "No user signed in.")
-			plugin.emitGodotSignal("auth_failure", "No user signed in.")
+			plugin.emitGodotSignal("link_with_google_failure", "No user signed in.")
 			return
 		}
 		if (!currentUser.isAnonymous) {
-			val hasGoogle = currentUser.providerData.any { it.providerId == GoogleAuthProvider.PROVIDER_ID }
-			if (hasGoogle) {
-				Log.d(TAG, "User is already linked with Google (uid=${currentUser.uid}). Skipping link.")
-				plugin.emitGodotSignal("auth_success", getCurrentUser())
-			} else {
-				Log.d(TAG, "User is not anonymous but not linked with Google. Skipping anonymous link.")
-				plugin.emitGodotSignal("auth_failure", "Current user is not anonymous. Use signInWithGoogle() instead.")
-			}
+			Log.d(TAG, "Current user is not anonymous (uid=${currentUser.uid}). Cannot link.")
+			plugin.emitGodotSignal("link_with_google_failure", "Current user is not anonymous.")
 			return
 		}
+		Log.d(TAG, "Linking anonymous user (uid=${currentUser.uid}) with Google.")
 		isLinkingAnonymous = true
 		signInWithGoogle()
 	}
@@ -196,16 +198,22 @@ class Authentication(private val plugin: FirebasePlugin) {
 	}
 
 	private fun linkWithGoogle(idToken: String) {
+		val currentUser = auth.currentUser
+		if (currentUser == null) {
+			Log.e(TAG, "No user signed in during linkWithGoogle.")
+			plugin.emitGodotSignal("link_with_google_failure", "No user signed in.")
+			return
+		}
 		val credential = GoogleAuthProvider.getCredential(idToken, null)
-		auth.currentUser!!.linkWithCredential(credential)
+		currentUser.linkWithCredential(credential)
 			.addOnSuccessListener { authResult ->
 				val uid = authResult.user?.uid
 				Log.d(TAG, "linkWithCredential:success -> $uid")
-				plugin.emitGodotSignal("auth_success", getCurrentUser())
+				plugin.emitGodotSignal("link_with_google_success", getCurrentUser())
 			}
 			.addOnFailureListener { e ->
 				Log.w(TAG, "linkWithCredential:failure", e)
-				plugin.emitGodotSignal("auth_failure", e.message ?: "Unknown error")
+				plugin.emitGodotSignal("link_with_google_failure", e.message ?: "Unknown error")
 			}
 	}
 

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
@@ -24,6 +24,7 @@ class Authentication(private val plugin: FirebasePlugin) {
 	private lateinit var activity: android.app.Activity
 	private val auth: FirebaseAuth = Firebase.auth
 	private lateinit var googleSignInClient: GoogleSignInClient
+	private var isLinkingAnonymous = false
 
 	fun authSignals(): MutableSet<SignalInfo> {
 		val signals: MutableSet<SignalInfo> = mutableSetOf()
@@ -61,8 +62,14 @@ class Authentication(private val plugin: FirebasePlugin) {
 			try {
 				val account = task.getResult(ApiException::class.java)!!
 				Log.d(TAG, "authWithGoogle:" + account.id)
-				authWithGoogle(account.idToken!!)
+				if (isLinkingAnonymous) {
+					isLinkingAnonymous = false
+					linkWithGoogle(account.idToken!!)
+				} else {
+					authWithGoogle(account.idToken!!)
+				}
 			} catch (e: ApiException) {
+				isLinkingAnonymous = false
 				Log.w(TAG, "Google sign in failed", e)
 				plugin.emitGodotSignal("auth_failure", e.message ?: "Unknown error")
 			}
@@ -146,6 +153,17 @@ class Authentication(private val plugin: FirebasePlugin) {
 		}
 	}
 
+	fun linkAnonymousWithGoogle() {
+		val currentUser = auth.currentUser
+		if (currentUser == null || !currentUser.isAnonymous) {
+			Log.e(TAG, "No anonymous user signed in.")
+			plugin.emitGodotSignal("auth_failure", "No anonymous user signed in.")
+			return
+		}
+		isLinkingAnonymous = true
+		signInWithGoogle()
+	}
+
 	private fun authWithGoogle(idToken: String) {
 		val credential = GoogleAuthProvider.getCredential(idToken, null)
 		auth.signInWithCredential(credential)
@@ -160,6 +178,20 @@ class Authentication(private val plugin: FirebasePlugin) {
 			}
 	}
 
+	private fun linkWithGoogle(idToken: String) {
+		val credential = GoogleAuthProvider.getCredential(idToken, null)
+		auth.currentUser!!.linkWithCredential(credential)
+			.addOnSuccessListener { authResult ->
+				val uid = authResult.user?.uid
+				Log.d(TAG, "linkWithCredential:success -> $uid")
+				plugin.emitGodotSignal("auth_success", getCurrentUser())
+			}
+			.addOnFailureListener { e ->
+				Log.w(TAG, "linkWithCredential:failure", e)
+				plugin.emitGodotSignal("auth_failure", e.message ?: "Unknown error")
+			}
+	}
+
 	fun getCurrentUser(): Dictionary {
 		val user = auth.currentUser
 		val userData = Dictionary()
@@ -168,6 +200,7 @@ class Authentication(private val plugin: FirebasePlugin) {
 			userData["email"] = user.email
 			userData["photoUrl"] = user.photoUrl?.toString()
 			userData["emailVerified"] = user.isEmailVerified
+			userData["isAnonymous"] = user.isAnonymous
 			userData["uid"] = user.uid
 		} else {
 			userData["error"] = "No user signed in"

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
@@ -161,9 +161,20 @@ class Authentication(private val plugin: FirebasePlugin) {
 
 	fun linkAnonymousWithGoogle() {
 		val currentUser = auth.currentUser
-		if (currentUser == null || !currentUser.isAnonymous) {
-			Log.e(TAG, "No anonymous user signed in.")
-			plugin.emitGodotSignal("auth_failure", "No anonymous user signed in.")
+		if (currentUser == null) {
+			Log.e(TAG, "No user signed in.")
+			plugin.emitGodotSignal("auth_failure", "No user signed in.")
+			return
+		}
+		if (!currentUser.isAnonymous) {
+			val hasGoogle = currentUser.providerData.any { it.providerId == GoogleAuthProvider.PROVIDER_ID }
+			if (hasGoogle) {
+				Log.d(TAG, "User is already linked with Google (uid=${currentUser.uid}). Skipping link.")
+				plugin.emitGodotSignal("auth_success", getCurrentUser())
+			} else {
+				Log.d(TAG, "User is not anonymous but not linked with Google. Skipping anonymous link.")
+				plugin.emitGodotSignal("auth_failure", "Current user is not anonymous. Use signInWithGoogle() instead.")
+			}
 			return
 		}
 		isLinkingAnonymous = true

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/Authentication.kt
@@ -77,6 +77,12 @@ class Authentication(private val plugin: FirebasePlugin) {
 	}
 
 	fun signInAnonymously() {
+		val currentUser = auth.currentUser
+		if (currentUser != null) {
+			Log.d(TAG, "User already signed in (uid=${currentUser.uid}, isAnonymous=${currentUser.isAnonymous}). Skipping anonymous sign-in.")
+			plugin.emitGodotSignal("auth_success", getCurrentUser())
+			return
+		}
 		auth.signInAnonymously()
 			.addOnSuccessListener {
 				val uid = it.user?.uid

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
@@ -65,6 +65,9 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 	fun signInWithGoogle() = auth.signInWithGoogle()
 
 	@UsedByGodot
+	fun linkAnonymousWithGoogle() = auth.linkAnonymousWithGoogle()
+
+	@UsedByGodot
 	fun getCurrentUser() = auth.getCurrentUser()
 
 	@UsedByGodot


### PR DESCRIPTION
Linked to Issue [#3 ](https://github.com/syntaxerror247/GodotFirebaseAndroid/issues/3)

Implements the ability to link an anonymous Firebase Auth user to a Google account, converting it into a permanent account while preserving the existing UID and data.

Based on the [Firebase anonymous-to-permanent account linking API](vscode-file://vscode-app/c:/Users/Sergames/AppData/Local/Programs/Microsoft%20VS%20Code/bdd88df003/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Usage
`
# Sign in anonymously first
Firebase.auth.sign_in_anonymously()

# Then link to Google
Firebase.auth.link_anonymous_with_google()
`
Emits auth_success with updated user data on success, or auth_failure if no anonymous user is signed in or linking fails.

Decisions
- Reuse existing auth_success / auth_failure signals rather than adding new link_success / link_failure signals — keeps the API simple and consistent.
- Use a boolean flag (isLinkingAnonymous) to share the Google Sign-In intent flow between signInWithGoogle and linkAnonymousWithGoogle — avoids duplicating the intent-launching and activity-result code.
- Add isAnonymous to getCurrentUser() dictionary — gives callers visibility into whether the current user is anonymous without a separate method.