### PR TITLE
Add `queryDocuments` method for Firestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Claude Code
+.claude/

--- a/firebase/export_scripts_template/modules/Firestore.gd
+++ b/firebase/export_scripts_template/modules/Firestore.gd
@@ -5,6 +5,7 @@ signal get_task_completed(result: Dictionary)
 signal update_task_completed(result: Dictionary)
 signal delete_task_completed(result: Dictionary)
 signal document_changed(document_path: String, data: Dictionary)
+signal query_task_completed(result: Dictionary)
 
 var _plugin_singleton: Object
 
@@ -16,6 +17,7 @@ func _connect_signals():
 	_plugin_singleton.connect("firestore_update_task_completed", update_task_completed.emit)
 	_plugin_singleton.connect("firestore_delete_task_completed", delete_task_completed.emit)
 	_plugin_singleton.connect("firestore_document_changed", document_changed.emit)
+	_plugin_singleton.connect("firestore_query_task_completed", query_task_completed.emit)
 
 func add_document(collection: String, data: Dictionary) -> void:
 	if _plugin_singleton:
@@ -44,6 +46,10 @@ func delete_document(collection: String, documentId: String) -> void:
 func listen_to_document(documentPath: String) -> void:
 	if _plugin_singleton:
 		_plugin_singleton.firestoreListenToDocument(documentPath)
+
+func query_documents(collection: String, filters: Array = [], order_by: String = "", order_descending: bool = false, limit_count: int = 0) -> void:
+	if _plugin_singleton:
+		_plugin_singleton.firestoreQueryDocuments(collection, filters, order_by, order_descending, limit_count)
 
 func stop_listening_to_document(documentPath: String) -> void:
 	if _plugin_singleton:

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
@@ -102,6 +102,9 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 	fun firestoreGetDocumentsInCollection(collection: String) = firestore.getDocumentsInCollection(collection)
 
 	@UsedByGodot
+	fun firestoreQueryDocuments(collection: String, filters: Array<Any?>, orderBy: String, orderDescending: Boolean, limitCount: Int) = firestore.queryDocuments(collection, filters, orderBy, orderDescending, limitCount)
+
+	@UsedByGodot
 	fun firestoreListenToDocument(documentPath: String) = firestore.listenToDocument(documentPath)
 
 	@UsedByGodot

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/Firestore.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/Firestore.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.firestore.firestore
 import org.godotengine.godot.Dictionary
@@ -24,6 +25,7 @@ class Firestore(private val plugin: FirebasePlugin) {
 		signals.add(SignalInfo("firestore_update_task_completed", Dictionary::class.java))
 		signals.add(SignalInfo("firestore_delete_task_completed", Dictionary::class.java))
 		signals.add(SignalInfo("firestore_document_changed", String::class.java, Dictionary::class.java))
+		signals.add(SignalInfo("firestore_query_task_completed", Dictionary::class.java))
 		return signals
 	}
 
@@ -153,6 +155,96 @@ class Firestore(private val plugin: FirebasePlugin) {
 		Log.d(TAG, "Stopped listening to document $documentPath")
 	}
 
+
+	fun queryDocuments(
+		collection: String,
+		filters: Array<Any?>,
+		orderBy: String,
+		orderDescending: Boolean,
+		limitCount: Int
+	) {
+		var query: Query = firestore.collection(collection)
+
+		for (item in filters) {
+			if (item is Dictionary) {
+				val field = item["field"] as? String ?: continue
+				val op = item["op"] as? String ?: continue
+				val value = item["value"] ?: continue
+
+				query = when (op) {
+					"==" -> query.whereEqualTo(field, value)
+					"!=" -> query.whereNotEqualTo(field, value)
+					"<" -> query.whereLessThan(field, value)
+					"<=" -> query.whereLessThanOrEqualTo(field, value)
+					">" -> query.whereGreaterThan(field, value)
+					">=" -> query.whereGreaterThanOrEqualTo(field, value)
+					"array_contains" -> query.whereArrayContains(field, value)
+					"in" -> {
+						val list = when (value) {
+							is Array<*> -> value.toList()
+							is List<*> -> value
+							else -> listOf(value)
+						}
+						query.whereIn(field, list)
+					}
+					"not_in" -> {
+						val list = when (value) {
+							is Array<*> -> value.toList()
+							is List<*> -> value
+							else -> listOf(value)
+						}
+						query.whereNotIn(field, list)
+					}
+					"array_contains_any" -> {
+						val list = when (value) {
+							is Array<*> -> value.toList()
+							is List<*> -> value
+							else -> listOf(value)
+						}
+						query.whereArrayContainsAny(field, list)
+					}
+					else -> {
+						Log.w(TAG, "Unknown filter operator: $op")
+						query
+					}
+				}
+			}
+		}
+
+		if (orderBy.isNotEmpty()) {
+			query = query.orderBy(
+				orderBy,
+				if (orderDescending) Query.Direction.DESCENDING else Query.Direction.ASCENDING
+			)
+		}
+
+		if (limitCount > 0) {
+			query = query.limit(limitCount.toLong())
+		}
+
+		query.get()
+			.addOnSuccessListener { querySnapshot ->
+				val documents = mutableListOf<Dictionary>()
+				for (doc in querySnapshot.documents) {
+					val docDict = Dictionary()
+					docDict["docID"] = doc.id
+					docDict["data"] = snapshotToDictionary(doc)
+					documents.add(docDict)
+				}
+				val result = Dictionary()
+				result["status"] = true
+				result["documents"] = documents.toTypedArray()
+				Log.d(TAG, "Query completed successfully, ${documents.size} documents found")
+				plugin.emitGodotSignal("firestore_query_task_completed", result)
+			}
+			.addOnFailureListener { e ->
+				Log.e(TAG, "Error querying documents:", e)
+				val result = Dictionary()
+				result["status"] = false
+				result["error"] = e.message ?: "Unknown error"
+				plugin.emitGodotSignal("firestore_query_task_completed", result)
+			}
+	}
 
 	private fun snapshotToDictionary(snapshot: DocumentSnapshot): Dictionary {
 		val dict = Dictionary()


### PR DESCRIPTION
Adds a `queryDocuments()` method to Firestore with support for filtered queries, ordering, and limits.

**Kotlin:** `Firestore.queryDocuments()` supports 10 filter operators (`==`, `!=`, `<`, `<=`, `>`, `>=`, `array_contains`, `in`, `not_in`, `array_contains_any`), `orderBy`, `orderDescending`, and `limitCount`. Emits `firestore_query_task_completed` signal.

**GDScript:** `Firebase.firestore.query_documents(collection, filters, order_by, order_descending, limit_count)`

Also adds `.claude/` to `.gitignore`.