### PR TITLE
Add basic Analytics module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Claude Code
+.claude/

--- a/firebase/build.gradle.kts
+++ b/firebase/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("com.google.firebase:firebase-firestore:25.1.4")
     implementation("com.google.firebase:firebase-database:21.0.0")
     implementation("com.google.firebase:firebase-storage:21.0.1")
+    implementation("com.google.firebase:firebase-analytics:22.4.0")
 }
 
 // BUILD TASKS DEFINITION

--- a/firebase/export_scripts_template/Firebase.gd
+++ b/firebase/export_scripts_template/Firebase.gd
@@ -4,6 +4,7 @@ var auth = preload("res://addons/GodotFirebaseAndroid/modules/Auth.gd").new()
 var firestore = preload("res://addons/GodotFirebaseAndroid/modules/Firestore.gd").new()
 var realtimeDB = preload("res://addons/GodotFirebaseAndroid/modules/RealtimeDB.gd").new()
 var storage = preload("res://addons/GodotFirebaseAndroid/modules/Storage.gd").new()
+var analytics = preload("res://addons/GodotFirebaseAndroid/modules/Analytics.gd").new()
 
 func _ready() -> void:
 	if Engine.has_singleton("GodotFirebaseAndroid"):
@@ -20,6 +21,9 @@ func _ready() -> void:
 		
 		storage._plugin_singleton = _plugin_singleton
 		storage._connect_signals()
+
+		analytics._plugin_singleton = _plugin_singleton
+		analytics._connect_signals()
 	else:
 		if not OS.has_feature("editor"):
 			printerr("GodotFirebaseAndroid singleton not found!")

--- a/firebase/export_scripts_template/modules/Analytics.gd
+++ b/firebase/export_scripts_template/modules/Analytics.gd
@@ -1,0 +1,26 @@
+extends Node
+
+var _plugin_singleton: Object
+
+func _connect_signals():
+	pass
+
+func log_event(name: String, parameters: Dictionary) -> void:
+	if _plugin_singleton:
+		_plugin_singleton.analyticsLogEvent(name, parameters)
+
+func set_user_property(name: String, value: String) -> void:
+	if _plugin_singleton:
+		_plugin_singleton.analyticsSetUserProperty(name, value)
+
+func set_user_id(id: String) -> void:
+	if _plugin_singleton:
+		_plugin_singleton.analyticsSetUserId(id)
+
+func set_analytics_collection_enabled(enabled: bool) -> void:
+	if _plugin_singleton:
+		_plugin_singleton.analyticsSetAnalyticsCollectionEnabled(enabled)
+
+func reset_analytics_data() -> void:
+	if _plugin_singleton:
+		_plugin_singleton.analyticsResetAnalyticsData()

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/Analytics.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/Analytics.kt
@@ -1,0 +1,62 @@
+package org.godotengine.plugin.firebase
+
+import android.os.Bundle
+import android.util.Log
+import com.google.firebase.analytics.FirebaseAnalytics
+import org.godotengine.godot.Dictionary
+import org.godotengine.godot.plugin.SignalInfo
+
+class Analytics(private val plugin: FirebasePlugin) {
+	companion object {
+		private const val TAG = "GodotFirebaseAnalytics"
+	}
+
+	private lateinit var firebaseAnalytics: FirebaseAnalytics
+
+	fun init(activity: android.app.Activity) {
+		firebaseAnalytics = FirebaseAnalytics.getInstance(activity)
+		Log.d(TAG, "Firebase Analytics initialized")
+	}
+
+	fun analyticsSignals(): MutableSet<SignalInfo> {
+		return mutableSetOf()
+	}
+
+	fun logEvent(name: String, parameters: Dictionary) {
+		val bundle = Bundle()
+		for (key in parameters.keys) {
+			val value = parameters[key]
+			when (value) {
+				is String -> bundle.putString(key.toString(), value)
+				is Int -> bundle.putLong(key.toString(), value.toLong())
+				is Long -> bundle.putLong(key.toString(), value)
+				is Double -> bundle.putDouble(key.toString(), value)
+				is Float -> bundle.putDouble(key.toString(), value.toDouble())
+				is Boolean -> bundle.putLong(key.toString(), if (value) 1L else 0L)
+				else -> bundle.putString(key.toString(), value.toString())
+			}
+		}
+		firebaseAnalytics.logEvent(name, bundle)
+		Log.d(TAG, "Event logged: $name")
+	}
+
+	fun setUserProperty(name: String, value: String) {
+		firebaseAnalytics.setUserProperty(name, value)
+		Log.d(TAG, "User property set: $name = $value")
+	}
+
+	fun setUserId(id: String) {
+		firebaseAnalytics.setUserId(id)
+		Log.d(TAG, "User ID set: $id")
+	}
+
+	fun setAnalyticsCollectionEnabled(enabled: Boolean) {
+		firebaseAnalytics.setAnalyticsCollectionEnabled(enabled)
+		Log.d(TAG, "Analytics collection enabled: $enabled")
+	}
+
+	fun resetAnalyticsData() {
+		firebaseAnalytics.resetAnalyticsData()
+		Log.d(TAG, "Analytics data reset")
+	}
+}

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
@@ -16,9 +16,13 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 	private val firestore = Firestore(this)
 	private val storage = CloudStorage(this)
 	private val realtimeDatabase = RealtimeDatabase(this)
+	private val analytics = Analytics(this)
 
 	override fun onMainCreate(activity: Activity?): View? {
-		activity?.let { auth.init(it) }
+		activity?.let {
+			auth.init(it)
+			analytics.init(it)
+		}
 		return super.onMainCreate(activity)
 	}
 
@@ -32,6 +36,7 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 		signals.addAll(firestore.firestoreSignals())
 		signals.addAll(realtimeDatabase.realtimeDbSignals())
 		signals.addAll(storage.storageSignals())
+		signals.addAll(analytics.analyticsSignals())
 		return signals
 	}
 
@@ -150,4 +155,23 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 
 	@UsedByGodot
 	fun rtdbStopListening(path: String) = realtimeDatabase.stopListening(path)
+
+	/**
+	 * Analytics
+	 */
+
+	@UsedByGodot
+	fun analyticsLogEvent(name: String, parameters: Dictionary) = analytics.logEvent(name, parameters)
+
+	@UsedByGodot
+	fun analyticsSetUserProperty(name: String, value: String) = analytics.setUserProperty(name, value)
+
+	@UsedByGodot
+	fun analyticsSetUserId(id: String) = analytics.setUserId(id)
+
+	@UsedByGodot
+	fun analyticsSetAnalyticsCollectionEnabled(enabled: Boolean) = analytics.setAnalyticsCollectionEnabled(enabled)
+
+	@UsedByGodot
+	fun analyticsResetAnalyticsData() = analytics.resetAnalyticsData()
 }


### PR DESCRIPTION
Adds a new Analytics module wrapping Firebase Analytics for event logging and user properties.

**Methods:** `log_event`, `set_user_property`, `set_user_id`, `set_analytics_collection_enabled`, `reset_analytics_data`

All methods are fire-and-forget (no signals needed). Also adds `.claude/` to `.gitignore`.