### PR TITLE
Add Remote Config module

### DIFF
--- a/firebase/build.gradle.kts
+++ b/firebase/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("com.google.firebase:firebase-firestore:25.1.4")
     implementation("com.google.firebase:firebase-database:21.0.0")
     implementation("com.google.firebase:firebase-storage:21.0.1")
+    implementation("com.google.firebase:firebase-config:22.0.1")
 }
 
 // BUILD TASKS DEFINITION

--- a/firebase/export_scripts_template/Firebase.gd
+++ b/firebase/export_scripts_template/Firebase.gd
@@ -4,6 +4,7 @@ var auth = preload("res://addons/GodotFirebaseAndroid/modules/Auth.gd").new()
 var firestore = preload("res://addons/GodotFirebaseAndroid/modules/Firestore.gd").new()
 var realtimeDB = preload("res://addons/GodotFirebaseAndroid/modules/RealtimeDB.gd").new()
 var storage = preload("res://addons/GodotFirebaseAndroid/modules/Storage.gd").new()
+var remote_config = preload("res://addons/GodotFirebaseAndroid/modules/RemoteConfig.gd").new()
 
 func _ready() -> void:
 	if Engine.has_singleton("GodotFirebaseAndroid"):
@@ -20,6 +21,9 @@ func _ready() -> void:
 		
 		storage._plugin_singleton = _plugin_singleton
 		storage._connect_signals()
+
+		remote_config._plugin_singleton = _plugin_singleton
+		remote_config._connect_signals()
 	else:
 		if not OS.has_feature("editor"):
 			printerr("GodotFirebaseAndroid singleton not found!")

--- a/firebase/export_scripts_template/modules/RemoteConfig.gd
+++ b/firebase/export_scripts_template/modules/RemoteConfig.gd
@@ -1,0 +1,46 @@
+extends Node
+
+signal fetch_completed(result: Dictionary)
+
+var _plugin_singleton: Object
+
+func _connect_signals():
+	if not _plugin_singleton:
+		return
+	_plugin_singleton.connect("remote_config_fetch_completed", fetch_completed.emit)
+
+func initialize() -> void:
+	if _plugin_singleton:
+		_plugin_singleton.remoteConfigInitialize()
+
+func set_defaults(defaults: Dictionary) -> void:
+	if _plugin_singleton:
+		_plugin_singleton.remoteConfigSetDefaults(defaults)
+
+func fetch_and_activate() -> void:
+	if _plugin_singleton:
+		_plugin_singleton.remoteConfigFetchAndActivate()
+
+func get_string(key: String) -> String:
+	var value := ""
+	if _plugin_singleton:
+		value = _plugin_singleton.remoteConfigGetString(key)
+	return value
+
+func get_bool(key: String) -> bool:
+	var value := false
+	if _plugin_singleton:
+		value = _plugin_singleton.remoteConfigGetBoolean(key)
+	return value
+
+func get_int(key: String) -> int:
+	var value := 0
+	if _plugin_singleton:
+		value = _plugin_singleton.remoteConfigGetLong(key)
+	return value
+
+func get_float(key: String) -> float:
+	var value := 0.0
+	if _plugin_singleton:
+		value = _plugin_singleton.remoteConfigGetDouble(key)
+	return value

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/FirebasePlugin.kt
@@ -16,6 +16,7 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 	private val firestore = Firestore(this)
 	private val storage = CloudStorage(this)
 	private val realtimeDatabase = RealtimeDatabase(this)
+	private val remoteConfig = RemoteConfig(this)
 
 	override fun onMainCreate(activity: Activity?): View? {
 		activity?.let { auth.init(it) }
@@ -32,6 +33,7 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 		signals.addAll(firestore.firestoreSignals())
 		signals.addAll(realtimeDatabase.realtimeDbSignals())
 		signals.addAll(storage.storageSignals())
+		signals.addAll(remoteConfig.remoteConfigSignals())
 		return signals
 	}
 
@@ -150,4 +152,29 @@ class FirebasePlugin(godot: Godot) : GodotPlugin(godot) {
 
 	@UsedByGodot
 	fun rtdbStopListening(path: String) = realtimeDatabase.stopListening(path)
+
+	/**
+	 * Remote Config
+	 */
+
+	@UsedByGodot
+	fun remoteConfigInitialize() = remoteConfig.initialize()
+
+	@UsedByGodot
+	fun remoteConfigSetDefaults(defaults: Dictionary) = remoteConfig.setDefaults(defaults)
+
+	@UsedByGodot
+	fun remoteConfigFetchAndActivate() = remoteConfig.fetchAndActivate()
+
+	@UsedByGodot
+	fun remoteConfigGetString(key: String) = remoteConfig.getString(key)
+
+	@UsedByGodot
+	fun remoteConfigGetBoolean(key: String) = remoteConfig.getBoolean(key)
+
+	@UsedByGodot
+	fun remoteConfigGetLong(key: String) = remoteConfig.getLong(key)
+
+	@UsedByGodot
+	fun remoteConfigGetDouble(key: String) = remoteConfig.getDouble(key)
 }

--- a/firebase/src/main/java/org/godotengine/plugin/firebase/RemoteConfig.kt
+++ b/firebase/src/main/java/org/godotengine/plugin/firebase/RemoteConfig.kt
@@ -1,0 +1,77 @@
+package org.godotengine.plugin.firebase
+
+import android.util.Log
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import org.godotengine.godot.Dictionary
+import org.godotengine.godot.plugin.SignalInfo
+
+class RemoteConfig(private val plugin: FirebasePlugin) {
+	companion object {
+		private const val TAG = "GodotFirebaseRemoteConfig"
+	}
+
+	private val remoteConfig: FirebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
+
+	fun remoteConfigSignals(): MutableSet<SignalInfo> {
+		val signals: MutableSet<SignalInfo> = mutableSetOf()
+		signals.add(SignalInfo("remote_config_fetch_completed", Dictionary::class.java))
+		return signals
+	}
+
+	fun initialize() {
+		val configSettings = FirebaseRemoteConfigSettings.Builder()
+			.setMinimumFetchIntervalInSeconds(3600)
+			.build()
+		remoteConfig.setConfigSettingsAsync(configSettings)
+		Log.d(TAG, "Remote Config initialized")
+	}
+
+	fun setDefaults(defaults: Dictionary) {
+		val defaultsMap = mutableMapOf<String, Any>()
+		for (key in defaults.keys) {
+			val value = defaults[key]
+			if (value != null) {
+				defaultsMap[key.toString()] = value
+			}
+		}
+		remoteConfig.setDefaultsAsync(defaultsMap)
+		Log.d(TAG, "Defaults set: ${defaultsMap.keys}")
+	}
+
+	fun fetchAndActivate() {
+		remoteConfig.fetchAndActivate()
+			.addOnSuccessListener { activated ->
+				val result = Dictionary()
+				result["status"] = true
+				result["activated"] = activated
+				result["error"] = ""
+				Log.d(TAG, "Fetch and activate succeeded (activated=$activated)")
+				plugin.emitGodotSignal("remote_config_fetch_completed", result)
+			}
+			.addOnFailureListener { e ->
+				val result = Dictionary()
+				result["status"] = false
+				result["activated"] = false
+				result["error"] = e.message ?: "Unknown error"
+				Log.e(TAG, "Fetch and activate failed", e)
+				plugin.emitGodotSignal("remote_config_fetch_completed", result)
+			}
+	}
+
+	fun getString(key: String): String {
+		return remoteConfig.getString(key)
+	}
+
+	fun getBoolean(key: String): Boolean {
+		return remoteConfig.getBoolean(key)
+	}
+
+	fun getLong(key: String): Long {
+		return remoteConfig.getLong(key)
+	}
+
+	fun getDouble(key: String): Double {
+		return remoteConfig.getDouble(key)
+	}
+}


### PR DESCRIPTION
Adds a new Remote Config module wrapping Firebase Remote Config.

**Methods:** `initialize`, `set_defaults`, `fetch_and_activate`, `get_string`, `get_bool`, `get_int`, `get_float`

**Signal:** `fetch_completed(result: Dictionary)` — emitted after `fetch_and_activate()` with `{status, activated, error}`.

Note: Remote Config works standalone without the Analytics module. However, if Analytics is also present, Remote Config gains the ability to target config values to user segments in the Firebase Console.