### PR TITLE
Add scrollable content and timestamped log panel to demo scenes

### DIFF
--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,18 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://dppun5r2ki736"]
+[gd_scene format=3 uid="uid://dppun5r2ki736"]
 
 [ext_resource type="Script" uid="uid://b56wdetifixsv" path="res://main.gd" id="1_ig7tw"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0xm2m"]
-draw_center = false
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-border_color = Color(0.14902, 0.117647, 0.854902, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_h2yge"]
 bg_color = Color(0.180392, 0.596078, 0.572549, 0.666667)
@@ -28,7 +16,19 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[node name="Main" type="Control"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0xm2m"]
+draw_center = false
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.14902, 0.117647, 0.854902, 1)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[node name="Main" type="Control" unique_id=418889083]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -37,7 +37,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_ig7tw")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="ColorRect" type="ColorRect" parent="." unique_id=1850932597]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -46,7 +46,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.133333, 0.133333, 0.133333, 1)
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=189691385]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -58,49 +58,49 @@ theme_override_constants/margin_top = 100
 theme_override_constants/margin_right = 60
 theme_override_constants/margin_bottom = 30
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1062512011]
 layout_mode = 2
 theme_override_constants/separation = 40
 alignment = 1
 
-[node name="Auth" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="Auth" type="Button" parent="MarginContainer/VBoxContainer" unique_id=537895669]
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
-theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
-theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
 theme_override_styles/normal = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
+theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
 text = "Authentication"
 
-[node name="Firestore" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="Firestore" type="Button" parent="MarginContainer/VBoxContainer" unique_id=1461008105]
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
-theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
-theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
 theme_override_styles/normal = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
+theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
 text = "Firestore"
 
-[node name="RealtimeDB" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="RealtimeDB" type="Button" parent="MarginContainer/VBoxContainer" unique_id=401983515]
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
-theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
-theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
 theme_override_styles/normal = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
+theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
 text = "Realtime Database"
 
-[node name="Storage" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="Storage" type="Button" parent="MarginContainer/VBoxContainer" unique_id=570714099]
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
-theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
-theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
 theme_override_styles/normal = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_1bvp3")
+theme_override_styles/hover = SubResource("StyleBoxFlat_h2yge")
+theme_override_styles/focus = SubResource("StyleBoxFlat_0xm2m")
 text = "Storage"
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Auth" to="." method="_on_auth_pressed"]

--- a/demo/scenes/authentication.gd
+++ b/demo/scenes/authentication.gd
@@ -2,8 +2,8 @@ extends Control
 
 @onready var output_panel = $MarginContainer/VBoxContainer/OutputPanel
 
-@onready var email = $MarginContainer/VBoxContainer/LineEdit
-@onready var password = $MarginContainer/VBoxContainer/LineEdit2
+@onready var email = $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/LineEdit
+@onready var password = $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/LineEdit2
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_WM_GO_BACK_REQUEST:
@@ -20,8 +20,18 @@ func _ready() -> void:
 	Firebase.auth.password_reset_sent.connect(print_output.bind("password_reset_sent"))
 	Firebase.auth.user_deleted.connect(print_output.bind("user_deleted"))
 
+
+func _log(message: String) -> void:
+	var time = Time.get_time_string_from_system()
+	output_panel.text += "[%s] %s\n" % [time, message]
+
+
 func print_output(arg, context: String):
-	output_panel.text += context + ": " +str(arg) + "\n"
+	_log(context + ": " + str(arg))
+
+
+func _on_clear_output_pressed() -> void:
+	output_panel.text = ""
 
 
 func _on_anonymous_sign_in_pressed() -> void:
@@ -49,7 +59,7 @@ func _on_get_user_data_pressed() -> void:
 
 
 func _on_is_signed_in_pressed() -> void:
-	print_output(Firebase.auth.is_signed_in(),"Is SignedIn")
+	print_output(Firebase.auth.is_signed_in(), "Is SignedIn")
 
 
 func _on_sign_out_pressed() -> void:

--- a/demo/scenes/authentication.tscn
+++ b/demo/scenes/authentication.tscn
@@ -1,18 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://b4wla4tiq5v36"]
+[gd_scene format=3 uid="uid://b4wla4tiq5v36"]
 
 [ext_resource type="Script" uid="uid://cbqguua1lmw1q" path="res://scenes/authentication.gd" id="1_3b5bi"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7dm0k"]
-draw_center = false
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-border_color = Color(0.14902, 0.117647, 0.854902, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
+[ext_resource type="Script" uid="uid://c1lwfy11opayr" path="res://scenes/scroll_container.gd" id="2_scroll"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ig7tw"]
 bg_color = Color(0.180392, 0.596078, 0.572549, 0.666667)
@@ -28,7 +17,19 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[node name="Authentication" type="Control"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7dm0k"]
+draw_center = false
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.14902, 0.117647, 0.854902, 1)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[node name="Authentication" type="Control" unique_id=1516008471]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -37,7 +38,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_3b5bi")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="ColorRect" type="ColorRect" parent="." unique_id=1301935428]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -46,7 +47,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.133333, 0.133333, 0.133333, 1)
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=1095550827]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -58,146 +59,168 @@ theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 40
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1580796319]
 layout_mode = 2
-theme_override_constants/separation = 36
-alignment = 1
+theme_override_constants/separation = 10
 
-[node name="LineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer" unique_id=45920927]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+script = ExtResource("2_scroll")
+
+[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer" unique_id=1862006050]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 20
+
+[node name="LineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1237815704]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 placeholder_text = "Email"
 
-[node name="LineEdit2" type="LineEdit" parent="MarginContainer/VBoxContainer"]
+[node name="LineEdit2" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1798937198]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 placeholder_text = "Password"
 
-[node name="anonymous_sign_in" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="anonymous_sign_in" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=176216697]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Sign In Anonymously"
 
-[node name="email_sign_up" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="email_sign_up" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=935803591]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Create User With Email Password"
 
-[node name="email_sign_in" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="email_sign_in" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1559812975]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Sign In With Email Password"
 
-[node name="email_verification" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="email_verification" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1671620727]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Send Email Verification"
 
-[node name="password_reset" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="password_reset" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1302125307]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Send Password Reset Email"
 
-[node name="google_sign_in" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="google_sign_in" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1871919082]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Sign In With Google"
 
-[node name="link_anonymous_with_google" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="link_anonymous_with_google" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=481102813]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Link Anonymous To Google"
 
-[node name="get_user_data" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="get_user_data" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=2078776940]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Get Current User Data"
 
-[node name="is_signed_in" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="is_signed_in" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1880020358]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Is Signed In"
 
-[node name="sign_out" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="sign_out" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=165805541]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Sign Out"
 
-[node name="delete_user" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="delete_user" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=215148053]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Delete Current User"
 
-[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer" unique_id=976434836]
+custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
-size_flags_vertical = 3
-theme_override_font_sizes/normal_font_size = 32
+theme_override_font_sizes/normal_font_size = 24
+scroll_following = true
 
-[connection signal="pressed" from="MarginContainer/VBoxContainer/anonymous_sign_in" to="." method="_on_anonymous_sign_in_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/email_sign_up" to="." method="_on_email_sign_up_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/email_sign_in" to="." method="_on_email_sign_in_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/email_verification" to="." method="_on_email_verification_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/password_reset" to="." method="_on_password_reset_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/google_sign_in" to="." method="_on_google_sign_in_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/link_anonymous_with_google" to="." method="_on_link_anonymous_with_google_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/get_user_data" to="." method="_on_get_user_data_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/is_signed_in" to="." method="_on_is_signed_in_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/sign_out" to="." method="_on_sign_out_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/delete_user" to="." method="_on_delete_user_pressed"]
+[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer" unique_id=869574200]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
+text = "Clear Output"
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/anonymous_sign_in" to="." method="_on_anonymous_sign_in_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/email_sign_up" to="." method="_on_email_sign_up_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/email_sign_in" to="." method="_on_email_sign_in_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/email_verification" to="." method="_on_email_verification_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/password_reset" to="." method="_on_password_reset_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/google_sign_in" to="." method="_on_google_sign_in_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/link_anonymous_with_google" to="." method="_on_link_anonymous_with_google_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/get_user_data" to="." method="_on_get_user_data_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/is_signed_in" to="." method="_on_is_signed_in_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/sign_out" to="." method="_on_sign_out_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/delete_user" to="." method="_on_delete_user_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/clear_output" to="." method="_on_clear_output_pressed"]

--- a/demo/scenes/firestore.gd
+++ b/demo/scenes/firestore.gd
@@ -1,7 +1,8 @@
 extends Control
 
-@onready var collection = $MarginContainer/VBoxContainer/HBoxContainer/collection
-@onready var docID = $MarginContainer/VBoxContainer/HBoxContainer/docID
+@onready var output_panel = $MarginContainer/VBoxContainer/OutputPanel
+@onready var collection = $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer/collection
+@onready var docID = $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer/docID
 @onready var pair_container = $ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container
 
 func _notification(what: int) -> void:
@@ -17,6 +18,11 @@ func _ready() -> void:
 	Firebase.firestore.document_changed.connect(print_listner_output.bind("document_changed"))
 
 
+func _log(message: String) -> void:
+	var time = Time.get_time_string_from_system()
+	output_panel.text += "[%s] %s\n" % [time, message]
+
+
 func get_dictionary_from_inputs() -> Dictionary:
 	var data_dict := Dictionary()
 	for pair in pair_container.get_children():
@@ -29,11 +35,17 @@ func get_dictionary_from_inputs() -> Dictionary:
 		data_dict[key] = value
 	return data_dict
 
+
 func print_output(arg, context: String):
-	$MarginContainer/VBoxContainer/OutputPanel.text += context + ": " +str(arg) + "\n"
+	_log(context + ": " + str(arg))
+
 
 func print_listner_output(arg, arg2, context: String):
-	$MarginContainer/VBoxContainer/OutputPanel.text += context + ": " +str(arg) + " -|- " +str(arg2) + "\n"
+	_log(context + ": " + str(arg) + " -|- " + str(arg2))
+
+
+func _on_clear_output_pressed() -> void:
+	output_panel.text = ""
 
 
 func _on_add_document_pressed() -> void:
@@ -41,7 +53,7 @@ func _on_add_document_pressed() -> void:
 
 
 func _on_set_document_pressed() -> void:
-	Firebase.firestore.set_document(collection.text, docID.text, get_dictionary_from_inputs(), $MarginContainer/VBoxContainer/HBoxContainer2/merge.button_pressed)
+	Firebase.firestore.set_document(collection.text, docID.text, get_dictionary_from_inputs(), $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2/merge.button_pressed)
 
 
 func _on_get_document_pressed() -> void:
@@ -61,12 +73,11 @@ func _on_delete_document_pressed() -> void:
 
 
 func _on_listen_to_document_pressed() -> void:
-	Firebase.firestore.listen_to_document(collection.text+"/"+docID.text)
+	Firebase.firestore.listen_to_document(collection.text + "/" + docID.text)
 
 
 func _on_stop_listening_to_document_pressed() -> void:
-	Firebase.firestore.stop_listening_to_document(collection.text+"/"+docID.text)
-
+	Firebase.firestore.stop_listening_to_document(collection.text + "/" + docID.text)
 
 
 func _on_manage_data_pressed() -> void:
@@ -77,7 +88,6 @@ func _on_add_pair_pressed() -> void:
 	var new_pair = $ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair.duplicate()
 	new_pair.show()
 	pair_container.add_child(new_pair)
-	pass
 
 
 func _on_close_pressed() -> void:

--- a/demo/scenes/firestore.tscn
+++ b/demo/scenes/firestore.tscn
@@ -1,21 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://by3lq5rrca21w"]
+[gd_scene format=3 uid="uid://by3lq5rrca21w"]
 
 [ext_resource type="Script" uid="uid://b6ce0u3c1yf13" path="res://scenes/firestore.gd" id="1_m3na1"]
-[ext_resource type="Script" path="res://scenes/scroll_container.gd" id="2_scroll"]
+[ext_resource type="Script" uid="uid://c1lwfy11opayr" path="res://scenes/scroll_container.gd" id="2_scroll"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7dm0k"]
-draw_center = false
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-border_color = Color(0.14902, 0.117647, 0.854902, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_u4mew"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_e3ux7"]
 bg_color = Color(0.205117, 0.205117, 0.205117, 0.666667)
 corner_radius_top_left = 20
 corner_radius_top_right = 20
@@ -29,8 +17,20 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_e3ux7"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_u4mew"]
 bg_color = Color(0.205117, 0.205117, 0.205117, 0.666667)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7dm0k"]
+draw_center = false
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.14902, 0.117647, 0.854902, 1)
 corner_radius_top_left = 20
 corner_radius_top_right = 20
 corner_radius_bottom_right = 20
@@ -54,7 +54,7 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[node name="Firestore" type="Control"]
+[node name="Firestore" type="Control" unique_id=1582451967]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -63,7 +63,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_m3na1")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="ColorRect" type="ColorRect" parent="." unique_id=1660552359]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -72,7 +72,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.133333, 0.133333, 0.133333, 1)
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=674206182]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -84,170 +84,169 @@ theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 40
 theme_override_constants/margin_bottom = 10
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1921191405]
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer" unique_id=1808379707]
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0
 script = ExtResource("2_scroll")
 
-[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer" unique_id=1157665160]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 20
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1559936862]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_constants/separation = 30
 
-[node name="collection" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer"]
+[node name="collection" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer" unique_id=700413340]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
 placeholder_text = "collection"
 alignment = 1
 
-[node name="docID" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer"]
+[node name="docID" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer" unique_id=1665016921]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
 placeholder_text = "doc ID"
 alignment = 1
 
-[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=841083874]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_u4mew")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_e3ux7")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_u4mew")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Manage Data"
 
-[node name="add_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="add_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1525866838]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Add Document"
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=12082284]
 layout_mode = 2
 theme_override_constants/separation = 20
 
-[node name="set_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2"]
+[node name="set_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2" unique_id=279690487]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Set Document"
 
-[node name="merge" type="CheckButton" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2"]
+[node name="merge" type="CheckButton" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2" unique_id=252244201]
 custom_minimum_size = Vector2(180, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Merge"
 alignment = 1
 
-[node name="get_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="get_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=593017580]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Get Document"
 
-[node name="get_documents_in_collection" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="get_documents_in_collection" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1150054568]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Get Documents in Collection"
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=670513634]
 layout_mode = 2
 theme_override_constants/separation = 26
 
-[node name="update_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3"]
+[node name="update_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3" unique_id=2013947020]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Update Document"
 
-[node name="delete_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3"]
+[node name="delete_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3" unique_id=224702515]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Delete Document"
 
-[node name="listen_to_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="listen_to_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=627750057]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Listen To Document"
 
-[node name="stop_listening_to_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="stop_listening_to_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=280566115]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Stop Listening To Document"
 
-[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer" unique_id=192997614]
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
-size_flags_vertical = 3
 theme_override_font_sizes/normal_font_size = 24
 scroll_following = true
 
-[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer" unique_id=431250705]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 theme_override_font_sizes/font_size = 24
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Clear Output"
 
-[node name="ManageDataPanel" type="PanelContainer" parent="."]
+[node name="ManageDataPanel" type="PanelContainer" parent="." unique_id=84878669]
 visible = false
 layout_mode = 1
 anchors_preset = 8
@@ -263,24 +262,24 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_pqa68")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="ManageDataPanel"]
+[node name="VBoxContainer" type="VBoxContainer" parent="ManageDataPanel" unique_id=1731628395]
 layout_mode = 2
 theme_override_constants/separation = 50
 
-[node name="ScrollContainer" type="ScrollContainer" parent="ManageDataPanel/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="ManageDataPanel/VBoxContainer" unique_id=1411359041]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="key_value_pair_container" type="VBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer"]
+[node name="key_value_pair_container" type="VBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer" unique_id=1469271539]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="sample_pair" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container"]
+[node name="sample_pair" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container" unique_id=1124087900]
 visible = false
 layout_mode = 2
 theme_override_constants/separation = 30
 
-[node name="key" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair"]
+[node name="key" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair" unique_id=874676520]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -288,7 +287,7 @@ theme_override_font_sizes/font_size = 32
 placeholder_text = "key"
 alignment = 1
 
-[node name="value" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair"]
+[node name="value" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair" unique_id=976655776]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -296,36 +295,36 @@ theme_override_font_sizes/font_size = 32
 placeholder_text = "values"
 alignment = 1
 
-[node name="CheckBox" type="CheckButton" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair"]
+[node name="CheckBox" type="CheckButton" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair" unique_id=1375760550]
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "Numeric"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer" unique_id=571912373]
 layout_mode = 2
 theme_override_constants/separation = 30
 alignment = 1
 
-[node name="close" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer"]
+[node name="close" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer" unique_id=909642421]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Close"
 
-[node name="add_pair" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer"]
+[node name="add_pair" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer" unique_id=971225860]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "New Pair"
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/manage_data" to="." method="_on_manage_data_pressed"]

--- a/demo/scenes/firestore.tscn
+++ b/demo/scenes/firestore.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=8 format=3 uid="uid://by3lq5rrca21w"]
+[gd_scene load_steps=9 format=3 uid="uid://by3lq5rrca21w"]
 
 [ext_resource type="Script" uid="uid://b6ce0u3c1yf13" path="res://scenes/firestore.gd" id="1_m3na1"]
+[ext_resource type="Script" path="res://scenes/scroll_container.gd" id="2_scroll"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7dm0k"]
 draw_center = false
@@ -85,29 +86,39 @@ theme_override_constants/margin_bottom = 10
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-theme_override_constants/separation = 36
-alignment = 1
+theme_override_constants/separation = 10
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+script = ExtResource("2_scroll")
+
+[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 20
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_constants/separation = 30
 
-[node name="collection" type="LineEdit" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="collection" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
 placeholder_text = "collection"
 alignment = 1
 
-[node name="docID" type="LineEdit" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="docID" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
 placeholder_text = "doc ID"
 alignment = 1
 
-[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -117,7 +128,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_e3ux7")
 text = "Manage Data"
 
-[node name="add_document" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="add_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -127,11 +138,11 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Add Document"
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 layout_mode = 2
 theme_override_constants/separation = 20
 
-[node name="set_document" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer2"]
+[node name="set_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -142,7 +153,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Set Document"
 
-[node name="merge" type="CheckButton" parent="MarginContainer/VBoxContainer/HBoxContainer2"]
+[node name="merge" type="CheckButton" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2"]
 custom_minimum_size = Vector2(180, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -153,7 +164,7 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Merge"
 alignment = 1
 
-[node name="get_document" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="get_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -163,7 +174,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Get Document"
 
-[node name="get_documents_in_collection" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="get_documents_in_collection" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -173,11 +184,11 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Get Documents in Collection"
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 layout_mode = 2
 theme_override_constants/separation = 26
 
-[node name="update_document" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer3"]
+[node name="update_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -188,7 +199,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Update Document"
 
-[node name="delete_document" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer3"]
+[node name="delete_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -199,7 +210,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Delete Document"
 
-[node name="listen_to_document" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="listen_to_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -209,7 +220,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Listen To Document"
 
-[node name="stop_listening_to_document" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="stop_listening_to_document" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -220,9 +231,21 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Stop Listening To Document"
 
 [node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_font_sizes/normal_font_size = 32
+theme_override_font_sizes/normal_font_size = 24
+scroll_following = true
+
+[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+text = "Clear Output"
 
 [node name="ManageDataPanel" type="PanelContainer" parent="."]
 visible = false
@@ -305,14 +328,15 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "New Pair"
 
-[connection signal="pressed" from="MarginContainer/VBoxContainer/manage_data" to="." method="_on_manage_data_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/add_document" to="." method="_on_add_document_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer2/set_document" to="." method="_on_set_document_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/get_document" to="." method="_on_get_document_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/get_documents_in_collection" to="." method="_on_get_documents_in_collection_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer3/update_document" to="." method="_on_update_document_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer3/delete_document" to="." method="_on_delete_document_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/listen_to_document" to="." method="_on_listen_to_document_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/stop_listening_to_document" to="." method="_on_stop_listening_to_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/manage_data" to="." method="_on_manage_data_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/add_document" to="." method="_on_add_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer2/set_document" to="." method="_on_set_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/get_document" to="." method="_on_get_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/get_documents_in_collection" to="." method="_on_get_documents_in_collection_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3/update_document" to="." method="_on_update_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer3/delete_document" to="." method="_on_delete_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/listen_to_document" to="." method="_on_listen_to_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/stop_listening_to_document" to="." method="_on_stop_listening_to_document_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/clear_output" to="." method="_on_clear_output_pressed"]
 [connection signal="pressed" from="ManageDataPanel/VBoxContainer/HBoxContainer/close" to="." method="_on_close_pressed"]
 [connection signal="pressed" from="ManageDataPanel/VBoxContainer/HBoxContainer/add_pair" to="." method="_on_add_pair_pressed"]

--- a/demo/scenes/realtime_db.gd
+++ b/demo/scenes/realtime_db.gd
@@ -1,6 +1,7 @@
 extends Control
 
-@onready var path = $MarginContainer/VBoxContainer/HBoxContainer/path
+@onready var output_panel = $MarginContainer/VBoxContainer/OutputPanel
+@onready var path = $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer/path
 @onready var pair_container = $ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container
 
 func _notification(what: int) -> void:
@@ -15,6 +16,12 @@ func _ready() -> void:
 	Firebase.realtimeDB.delete_task_completed.connect(print_output.bind("delete_task_completed"))
 	Firebase.realtimeDB.db_value_changed.connect(print_listner_output.bind("db_value_changed"))
 
+
+func _log(message: String) -> void:
+	var time = Time.get_time_string_from_system()
+	output_panel.text += "[%s] %s\n" % [time, message]
+
+
 func get_dictionary_from_inputs() -> Dictionary:
 	var data_dict := Dictionary()
 	for pair in pair_container.get_children():
@@ -27,11 +34,17 @@ func get_dictionary_from_inputs() -> Dictionary:
 		data_dict[key] = value
 	return data_dict
 
+
 func print_output(arg, context: String):
-	$MarginContainer/VBoxContainer/OutputPanel.text += context + ": " +str(arg) + "\n"
+	_log(context + ": " + str(arg))
+
 
 func print_listner_output(arg, arg2, context: String):
-	$MarginContainer/VBoxContainer/OutputPanel.text += context + ": " +str(arg) + " -|- " +str(arg2) + "\n"
+	_log(context + ": " + str(arg) + " -|- " + str(arg2))
+
+
+func _on_clear_output_pressed() -> void:
+	output_panel.text = ""
 
 
 func _on_set_value_pressed() -> void:
@@ -56,7 +69,6 @@ func _on_listen_to_path_pressed() -> void:
 
 func _on_stop_listening_pressed() -> void:
 	Firebase.realtimeDB.stop_listening(path.text)
-
 
 
 func _on_manage_data_pressed() -> void:

--- a/demo/scenes/realtime_db.tscn
+++ b/demo/scenes/realtime_db.tscn
@@ -1,21 +1,9 @@
-[gd_scene load_steps=14 format=3 uid="uid://c55qaxgt7rib8"]
+[gd_scene format=3 uid="uid://c55qaxgt7rib8"]
 
 [ext_resource type="Script" uid="uid://d2e4rd8p0lrkq" path="res://scenes/realtime_db.gd" id="1_t2rp6"]
-[ext_resource type="Script" path="res://scenes/scroll_container.gd" id="2_scroll"]
+[ext_resource type="Script" uid="uid://c1lwfy11opayr" path="res://scenes/scroll_container.gd" id="2_scroll"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1ykmf"]
-draw_center = false
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-border_color = Color(0.14902, 0.117647, 0.854902, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3kwyk"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hfmmi"]
 bg_color = Color(0.205117, 0.205117, 0.205117, 0.666667)
 corner_radius_top_left = 20
 corner_radius_top_right = 20
@@ -29,14 +17,14 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hfmmi"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3kwyk"]
 bg_color = Color(0.205117, 0.205117, 0.205117, 0.666667)
 corner_radius_top_left = 20
 corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7dm0k"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1ykmf"]
 draw_center = false
 border_width_left = 3
 border_width_top = 3
@@ -62,24 +50,24 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bky7l"]
-content_margin_left = 20.0
-content_margin_top = 20.0
-content_margin_right = 20.0
-content_margin_bottom = 20.0
-bg_color = Color(0.2484, 0.2484, 0.2484, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_06hu1"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7dm0k"]
 draw_center = false
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
 border_color = Color(0.14902, 0.117647, 0.854902, 1)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bky7l"]
+content_margin_left = 20.0
+content_margin_top = 20.0
+content_margin_right = 20.0
+content_margin_bottom = 20.0
+bg_color = Color(0.2484, 0.2484, 0.2484, 1)
 corner_radius_top_left = 20
 corner_radius_top_right = 20
 corner_radius_bottom_right = 20
@@ -99,7 +87,19 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[node name="RealtimeDatabase" type="Control"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_06hu1"]
+draw_center = false
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.14902, 0.117647, 0.854902, 1)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[node name="RealtimeDatabase" type="Control" unique_id=499339871]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -108,7 +108,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_t2rp6")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="ColorRect" type="ColorRect" parent="." unique_id=729099514]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -117,7 +117,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.133333, 0.133333, 0.133333, 1)
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=1737132860]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -129,121 +129,120 @@ theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 40
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1602028102]
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer" unique_id=948446788]
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0
 script = ExtResource("2_scroll")
 
-[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer" unique_id=334481448]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 20
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1412249608]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_constants/separation = 30
 
-[node name="path" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer"]
+[node name="path" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer" unique_id=907271452]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
 placeholder_text = "path"
 alignment = 1
 
-[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=2085366332]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_1ykmf")
-theme_override_styles/hover = SubResource("StyleBoxFlat_3kwyk")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_iw5n2")
 theme_override_styles/normal = SubResource("StyleBoxFlat_hfmmi")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_iw5n2")
+theme_override_styles/hover = SubResource("StyleBoxFlat_3kwyk")
+theme_override_styles/focus = SubResource("StyleBoxFlat_1ykmf")
 text = "Manage Data"
 
-[node name="set_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="set_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1435841510]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Set Value"
 
-[node name="get_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="get_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=2129767826]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Get Value"
 
-[node name="update_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="update_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1089191624]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Update Value"
 
-[node name="delete_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="delete_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=929275813]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Delete Value"
 
-[node name="listen_to_path" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="listen_to_path" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=359477331]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Listen To Path"
 
-[node name="stop_listening" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="stop_listening" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1693330522]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Stop Listening"
 
-[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer" unique_id=1607863522]
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
-size_flags_vertical = 3
 theme_override_font_sizes/normal_font_size = 24
 scroll_following = true
 
-[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer" unique_id=675025582]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 theme_override_font_sizes/font_size = 24
-theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
 text = "Clear Output"
 
-[node name="ManageDataPanel" type="PanelContainer" parent="."]
+[node name="ManageDataPanel" type="PanelContainer" parent="." unique_id=289605140]
 visible = false
 layout_mode = 1
 anchors_preset = 8
@@ -259,24 +258,24 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_bky7l")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="ManageDataPanel"]
+[node name="VBoxContainer" type="VBoxContainer" parent="ManageDataPanel" unique_id=2118414470]
 layout_mode = 2
 theme_override_constants/separation = 50
 
-[node name="ScrollContainer" type="ScrollContainer" parent="ManageDataPanel/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="ManageDataPanel/VBoxContainer" unique_id=1782538888]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="key_value_pair_container" type="VBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer"]
+[node name="key_value_pair_container" type="VBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer" unique_id=347261149]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="sample_pair" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container"]
+[node name="sample_pair" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container" unique_id=1183993737]
 visible = false
 layout_mode = 2
 theme_override_constants/separation = 30
 
-[node name="key" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair"]
+[node name="key" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair" unique_id=984125522]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -284,7 +283,7 @@ theme_override_font_sizes/font_size = 32
 placeholder_text = "key"
 alignment = 1
 
-[node name="value" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair"]
+[node name="value" type="LineEdit" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair" unique_id=1345338338]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -292,36 +291,36 @@ theme_override_font_sizes/font_size = 32
 placeholder_text = "values"
 alignment = 1
 
-[node name="CheckBox" type="CheckButton" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair"]
+[node name="CheckBox" type="CheckButton" parent="ManageDataPanel/VBoxContainer/ScrollContainer/key_value_pair_container/sample_pair" unique_id=1323611838]
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "Numeric"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="ManageDataPanel/VBoxContainer" unique_id=77088865]
 layout_mode = 2
 theme_override_constants/separation = 30
 alignment = 1
 
-[node name="close" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer"]
+[node name="close" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer" unique_id=1425540624]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_06hu1")
-theme_override_styles/hover = SubResource("StyleBoxFlat_q5sw8")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bmyp4")
 theme_override_styles/normal = SubResource("StyleBoxFlat_q5sw8")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_bmyp4")
+theme_override_styles/hover = SubResource("StyleBoxFlat_q5sw8")
+theme_override_styles/focus = SubResource("StyleBoxFlat_06hu1")
 text = "Close"
 
-[node name="add_pair" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer"]
+[node name="add_pair" type="Button" parent="ManageDataPanel/VBoxContainer/HBoxContainer" unique_id=321752229]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_06hu1")
-theme_override_styles/hover = SubResource("StyleBoxFlat_q5sw8")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bmyp4")
 theme_override_styles/normal = SubResource("StyleBoxFlat_q5sw8")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_bmyp4")
+theme_override_styles/hover = SubResource("StyleBoxFlat_q5sw8")
+theme_override_styles/focus = SubResource("StyleBoxFlat_06hu1")
 text = "New Pair"
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/manage_data" to="." method="_on_manage_data_pressed"]

--- a/demo/scenes/realtime_db.tscn
+++ b/demo/scenes/realtime_db.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=13 format=3 uid="uid://c55qaxgt7rib8"]
+[gd_scene load_steps=14 format=3 uid="uid://c55qaxgt7rib8"]
 
 [ext_resource type="Script" uid="uid://d2e4rd8p0lrkq" path="res://scenes/realtime_db.gd" id="1_t2rp6"]
+[ext_resource type="Script" path="res://scenes/scroll_container.gd" id="2_scroll"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1ykmf"]
 draw_center = false
@@ -130,22 +131,32 @@ theme_override_constants/margin_bottom = 20
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-theme_override_constants/separation = 36
-alignment = 1
+theme_override_constants/separation = 10
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+script = ExtResource("2_scroll")
+
+[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 20
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_constants/separation = 30
 
-[node name="path" type="LineEdit" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="path" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 32
 placeholder_text = "path"
 alignment = 1
 
-[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="manage_data" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -155,7 +166,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_iw5n2")
 theme_override_styles/normal = SubResource("StyleBoxFlat_hfmmi")
 text = "Manage Data"
 
-[node name="set_value" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="set_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -165,7 +176,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Set Value"
 
-[node name="get_value" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="get_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -175,7 +186,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Get Value"
 
-[node name="update_value" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="update_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -185,7 +196,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Update Value"
 
-[node name="delete_value" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="delete_value" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -195,7 +206,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Delete Value"
 
-[node name="listen_to_path" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="listen_to_path" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -205,7 +216,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Listen To Path"
 
-[node name="stop_listening" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="stop_listening" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 70)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -216,9 +227,21 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
 text = "Stop Listening"
 
 [node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_font_sizes/normal_font_size = 32
+theme_override_font_sizes/normal_font_size = 24
+scroll_following = true
+
+[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+theme_override_styles/focus = SubResource("StyleBoxFlat_7dm0k")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ig7tw")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_0xm2m")
+theme_override_styles/normal = SubResource("StyleBoxFlat_ig7tw")
+text = "Clear Output"
 
 [node name="ManageDataPanel" type="PanelContainer" parent="."]
 visible = false
@@ -301,12 +324,13 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_bmyp4")
 theme_override_styles/normal = SubResource("StyleBoxFlat_q5sw8")
 text = "New Pair"
 
-[connection signal="pressed" from="MarginContainer/VBoxContainer/manage_data" to="." method="_on_manage_data_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/set_value" to="." method="_on_set_value_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/get_value" to="." method="_on_get_value_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/update_value" to="." method="_on_update_value_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/delete_value" to="." method="_on_delete_value_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/listen_to_path" to="." method="_on_listen_to_path_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/stop_listening" to="." method="_on_stop_listening_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/manage_data" to="." method="_on_manage_data_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/set_value" to="." method="_on_set_value_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/get_value" to="." method="_on_get_value_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/update_value" to="." method="_on_update_value_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/delete_value" to="." method="_on_delete_value_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/listen_to_path" to="." method="_on_listen_to_path_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/stop_listening" to="." method="_on_stop_listening_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/clear_output" to="." method="_on_clear_output_pressed"]
 [connection signal="pressed" from="ManageDataPanel/VBoxContainer/HBoxContainer/close" to="." method="_on_close_pressed"]
 [connection signal="pressed" from="ManageDataPanel/VBoxContainer/HBoxContainer/add_pair" to="." method="_on_add_pair_pressed"]

--- a/demo/scenes/scroll_container.gd
+++ b/demo/scenes/scroll_container.gd
@@ -1,0 +1,37 @@
+extends ScrollContainer
+
+var swiping = false
+var swipe_start: Vector2
+var swipe_mouse_start: Vector2
+var is_enabled: bool = true
+
+func _input(ev):
+	if is_enabled:
+		if self.get_global_rect().has_point(get_global_mouse_position()):
+			if ev is InputEventMouseButton:
+				if ev.pressed:
+					swip_controller(true)
+					swipe_start = Vector2(get_h_scroll(), get_v_scroll())
+					swipe_mouse_start = ev.position
+				else:
+					swip_controller(false)
+			elif swiping and ev is InputEventMouseMotion:
+				var delta = ev.position - swipe_mouse_start
+				if horizontal_scroll_mode != ScrollMode.SCROLL_MODE_DISABLED:
+					set_h_scroll(swipe_start.x - delta.x)
+				if vertical_scroll_mode != ScrollMode.SCROLL_MODE_DISABLED:
+					set_v_scroll(swipe_start.y - delta.y)
+		else:
+			swip_controller(false)
+
+func swip_controller(is_swiping) -> void:
+	swiping = is_swiping
+
+func swip_enabler(p_is_enabled: bool) -> void:
+	mouse_filter = Control.MOUSE_FILTER_PASS
+	vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
+	is_enabled = p_is_enabled
+	swip_controller(false)
+	if not is_enabled:
+		vertical_scroll_mode = ScrollContainer.SCROLL_MODE_SHOW_NEVER
+		mouse_filter = Control.MOUSE_FILTER_IGNORE

--- a/demo/scenes/scroll_container.gd.uid
+++ b/demo/scenes/scroll_container.gd.uid
@@ -1,0 +1,1 @@
+uid://c1lwfy11opayr

--- a/demo/scenes/storage.gd
+++ b/demo/scenes/storage.gd
@@ -2,14 +2,15 @@ extends Control
 
 @onready var output_panel = $MarginContainer/VBoxContainer/OutputPanel
 
-@onready var download_path = $MarginContainer/VBoxContainer/LineEdit2
-@onready var cloud_storage_path = $MarginContainer/VBoxContainer/LineEdit3
+@onready var download_path = $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/LineEdit2
+@onready var cloud_storage_path = $MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/LineEdit3
 
 var selected_image_path: String
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_WM_GO_BACK_REQUEST:
 		get_tree().change_scene_to_packed(load("res://main.tscn"))
+
 
 func _ready() -> void:
 	Firebase.storage.upload_task_completed.connect(print_output.bind("upload_task_completed"))
@@ -18,11 +19,22 @@ func _ready() -> void:
 	Firebase.storage.list_task_completed.connect(print_output.bind("list_task_completed"))
 	OS.request_permissions()
 
-func _on_get_image_path_pressed() -> void:
-	$FileDialog.popup()
+
+func _log(message: String) -> void:
+	var time = Time.get_time_string_from_system()
+	output_panel.text += "[%s] %s\n" % [time, message]
+
 
 func print_output(arg, context: String):
-	$MarginContainer/VBoxContainer/OutputPanel.text += context + ": " +str(arg) + "\n"
+	_log(context + ": " + str(arg))
+
+
+func _on_clear_output_pressed() -> void:
+	output_panel.text = ""
+
+
+func _on_get_image_path_pressed() -> void:
+	$FileDialog.popup()
 
 
 func _on_upload_file_pressed() -> void:
@@ -46,7 +58,7 @@ func _on_list_files_pressed() -> void:
 
 
 func _on_file_dialog_file_selected(path: String) -> void:
-	print(path)
+	_log("Selected: " + path)
 	selected_image_path = path
 
 

--- a/demo/scenes/storage.tscn
+++ b/demo/scenes/storage.tscn
@@ -1,19 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://cpxjrj5th1sdt"]
+[gd_scene format=3 uid="uid://cpxjrj5th1sdt"]
 
 [ext_resource type="Script" uid="uid://bqo5rpk2iaqo3" path="res://scenes/storage.gd" id="1_ueev3"]
-[ext_resource type="Script" path="res://scenes/scroll_container.gd" id="2_scroll"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nnb4j"]
-draw_center = false
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-border_color = Color(0.14902, 0.117647, 0.854902, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
+[ext_resource type="Script" uid="uid://c1lwfy11opayr" path="res://scenes/scroll_container.gd" id="2_scroll"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ykan5"]
 bg_color = Color(0.180392, 0.596078, 0.572549, 0.666667)
@@ -29,7 +17,19 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[node name="Storage" type="Control"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nnb4j"]
+draw_center = false
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.14902, 0.117647, 0.854902, 1)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[node name="Storage" type="Control" unique_id=822135332]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -38,7 +38,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_ueev3")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="ColorRect" type="ColorRect" parent="." unique_id=940358115]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -47,7 +47,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.133333, 0.133333, 0.133333, 1)
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=167049553]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -59,117 +59,116 @@ theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 40
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1796174638]
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer" unique_id=615970092]
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0
 script = ExtResource("2_scroll")
 
-[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer" unique_id=1508038207]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 20
 
-[node name="get_image_path" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="get_image_path" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=2115693194]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "select an Image to upload"
 
-[node name="LineEdit2" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="LineEdit2" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1465489189]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 placeholder_text = "download file path (local storage)"
 
-[node name="LineEdit3" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="LineEdit3" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1951687850]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 placeholder_text = "file path (Cloud Storage)"
 
-[node name="upload_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="upload_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=900130634]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
 text = "Upload File"
 
-[node name="download_url" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="download_url" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1787837820]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
 text = "Get Download URL"
 
-[node name="download_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="download_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1152021673]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
 text = "Download File"
 
-[node name="get_metadata" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="get_metadata" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1488147538]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
 text = "Get Metadata"
 
-[node name="delete_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="delete_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=971912616]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
 text = "Delete File"
 
-[node name="list_files" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
+[node name="list_files" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer" unique_id=1218832507]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
-theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
 text = "List Files"
 
-[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer" unique_id=1757809382]
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
-size_flags_vertical = 3
 theme_override_font_sizes/normal_font_size = 24
 scroll_following = true
 
-[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer" unique_id=143818203]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 theme_override_font_sizes/font_size = 24
-theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
-theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
 text = "Clear Output"
 
-[node name="FileDialog" type="FileDialog" parent="."]
+[node name="FileDialog" type="FileDialog" parent="." unique_id=164122850]
 title = "Open a File"
 position = Vector2i(0, 36)
 ok_button_text = "Open"

--- a/demo/scenes/storage.tscn
+++ b/demo/scenes/storage.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://cpxjrj5th1sdt"]
+[gd_scene load_steps=6 format=3 uid="uid://cpxjrj5th1sdt"]
 
 [ext_resource type="Script" uid="uid://bqo5rpk2iaqo3" path="res://scenes/storage.gd" id="1_ueev3"]
+[ext_resource type="Script" path="res://scenes/scroll_container.gd" id="2_scroll"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nnb4j"]
 draw_center = false
@@ -60,28 +61,38 @@ theme_override_constants/margin_bottom = 20
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-theme_override_constants/separation = 36
-alignment = 1
+theme_override_constants/separation = 10
 
-[node name="get_image_path" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+script = ExtResource("2_scroll")
+
+[node name="ButtonContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 20
+
+[node name="get_image_path" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "select an Image to upload"
 
-[node name="LineEdit2" type="LineEdit" parent="MarginContainer/VBoxContainer"]
+[node name="LineEdit2" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 placeholder_text = "download file path (local storage)"
 
-[node name="LineEdit3" type="LineEdit" parent="MarginContainer/VBoxContainer"]
+[node name="LineEdit3" type="LineEdit" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 placeholder_text = "file path (Cloud Storage)"
 
-[node name="upload_file" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="upload_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -91,7 +102,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
 text = "Upload File"
 
-[node name="download_url" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="download_url" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -101,7 +112,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
 text = "Get Download URL"
 
-[node name="download_file" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="download_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -111,7 +122,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
 text = "Download File"
 
-[node name="get_metadata" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="get_metadata" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -121,7 +132,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
 text = "Get Metadata"
 
-[node name="delete_file" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="delete_file" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -131,7 +142,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
 theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
 text = "Delete File"
 
-[node name="list_files" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="list_files" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer"]
 custom_minimum_size = Vector2(120, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
@@ -142,9 +153,21 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
 text = "List Files"
 
 [node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_font_sizes/normal_font_size = 32
+theme_override_font_sizes/normal_font_size = 24
+scroll_following = true
+
+[node name="clear_output" type="Button" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+theme_override_styles/focus = SubResource("StyleBoxFlat_nnb4j")
+theme_override_styles/hover = SubResource("StyleBoxFlat_ykan5")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_taf4q")
+theme_override_styles/normal = SubResource("StyleBoxFlat_ykan5")
+text = "Clear Output"
 
 [node name="FileDialog" type="FileDialog" parent="."]
 title = "Open a File"
@@ -155,11 +178,12 @@ access = 2
 filters = PackedStringArray("image/*")
 use_native_dialog = true
 
-[connection signal="pressed" from="MarginContainer/VBoxContainer/get_image_path" to="." method="_on_get_image_path_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/upload_file" to="." method="_on_upload_file_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/download_url" to="." method="_on_download_url_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/download_file" to="." method="_on_download_file_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/get_metadata" to="." method="_on_get_metadata_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/delete_file" to="." method="_on_delete_file_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/list_files" to="." method="_on_list_files_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/get_image_path" to="." method="_on_get_image_path_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/upload_file" to="." method="_on_upload_file_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/download_url" to="." method="_on_download_url_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/download_file" to="." method="_on_download_file_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/get_metadata" to="." method="_on_get_metadata_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/delete_file" to="." method="_on_delete_file_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ScrollContainer/ButtonContainer/list_files" to="." method="_on_list_files_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/clear_output" to="." method="_on_clear_output_pressed"]
 [connection signal="file_selected" from="FileDialog" to="." method="_on_file_dialog_file_selected"]


### PR DESCRIPTION
## Summary
- Wrap demo scene buttons in a touch-scrollable `ScrollContainer` for easier navigation on mobile
- Add timestamped log output panel (`[HH:MM:SS] message` format) to all 4 demo scenes (Auth, Firestore, RealtimeDB, Storage)
- Add "Clear Output" button to reset the log panel
- Applies to: `authentication`, `firestore`, `realtime_db`, `storage` scenes

## Test plan
- [ ] Open each demo scene in Godot editor and verify layout looks correct
- [ ] Deploy to Android device and verify touch-scroll works on the button area
- [ ] Trigger actions (e.g. sign in, upload file) and verify timestamped logs appear
- [ ] Tap "Clear Output" and verify log panel resets
- [ ] Verify Android back button still navigates back to main menu